### PR TITLE
Implements during ReQL command

### DIFF
--- a/lib/no_brainer/symbol_decoration.rb
+++ b/lib/no_brainer/symbol_decoration.rb
@@ -1,5 +1,5 @@
 module NoBrainer::SymbolDecoration
-  NON_CHAINABLE_OPERATORS = %w(in eq gt ge gte lt le lte defined undefined near intersects include).map(&:to_sym)
+  NON_CHAINABLE_OPERATORS = %w(in eq gt ge gte lt le lte defined undefined near intersects include during).map(&:to_sym)
   CHAINABLE_OPERATORS = %w(not any all).map(&:to_sym)
   OPERATORS = CHAINABLE_OPERATORS + NON_CHAINABLE_OPERATORS
 


### PR DESCRIPTION
This PR implements [the `during` ReQL command](https://rethinkdb.com/api/ruby/during/) which allow to filter documents having the given filed between the 2 given times.

Here is an example of its usage:

```ruby
User.where(:created_at.during(1.month.ago, Time.current)).to_a
```

It returns all the created `User`s in the last month period of time.

It replaces using the combinaison of `gt` and `lt`.