### PR TITLE
Implements polymorphic associations (Closes #51)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,11 @@
+require:
+  - rubocop-rspec
+
+AllCops:
+  NewCops: enable
+
+Metrics/BlockLength:
+  IgnoredMethods: ['describe', 'context']
+
+Style/Documentation:
+  Enabled: No

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
+### Added
+- Implements polymorphic associations
 
 ## [0.42.0] - 2022-06-15
 ### Added

--- a/lib/no_brainer/criteria/join.rb
+++ b/lib/no_brainer/criteria/join.rb
@@ -16,6 +16,7 @@ module NoBrainer::Criteria::Join
         association = model.association_metadata[k.to_sym]
         raise "`#{k}' must be an association on `#{model}'" unless association
         raise "join() does not support through associations" if association.options[:through]
+        raise "join() does not support polymorphic associations" if association.options[:polymorphic]
 
         criteria = association.base_criteria
         criteria = case v

--- a/lib/no_brainer/document/association/core.rb
+++ b/lib/no_brainer/document/association/core.rb
@@ -33,8 +33,8 @@ module NoBrainer::Document::Association::Core
 
     def hook
       options.assert_valid_keys(*self.class.const_get(:VALID_OPTIONS))
-      delegate("#{target_name}=", :write)
-      delegate("#{target_name}", :read)
+      delegate("#{target_name}=", "#{'polymorphic_' if options[:polymorphic]}write".to_sym)
+      delegate("#{target_name}", "#{'polymorphic_' if options[:polymorphic]}read".to_sym)
     end
 
     def add_callback_for(what)
@@ -62,7 +62,8 @@ module NoBrainer::Document::Association::Core
 
   included { attr_accessor :metadata, :owner }
 
-  delegate :primary_key, :foreign_key, :target_name, :target_model, :base_criteria, :to => :metadata
+  delegate :primary_key, :foreign_key, :foreign_type, :target_name,
+           :target_model, :base_criteria, :to => :metadata
 
   def initialize(metadata, owner)
     @metadata, @owner = metadata, owner

--- a/lib/no_brainer/error.rb
+++ b/lib/no_brainer/error.rb
@@ -1,19 +1,21 @@
+# frozen_string_literal: true
+
 module NoBrainer::Error
-  class Connection              < RuntimeError; end
-  class DocumentNotFound        < RuntimeError; end
-  class DocumentNotPersisted    < RuntimeError; end
-  class ChildrenExist           < RuntimeError; end
-  class CannotUseIndex          < RuntimeError; end
-  class MissingIndex            < RuntimeError; end
-  class AssociationNotPersisted < RuntimeError; end
-  class ReadonlyField           < RuntimeError; end
-  class MissingAttribute        < RuntimeError; end
-  class UnknownAttribute        < RuntimeError; end
-  class AtomicBlock             < RuntimeError; end
-  class LostLock                < RuntimeError; end
-  class LockInvalidOp           < RuntimeError; end
-  class LockUnavailable         < RuntimeError; end
-  class InvalidPolymorphicType  < RuntimeError; end
+  class AssociationNotPersisted                   < RuntimeError; end
+  class AtomicBlock                               < RuntimeError; end
+  class ChildrenExist                             < RuntimeError; end
+  class Connection                                < RuntimeError; end
+  class DocumentNotFound                          < RuntimeError; end
+  class DocumentNotPersisted                      < RuntimeError; end
+  class InvalidPolymorphicType                    < RuntimeError; end
+  class LockInvalidOp                             < RuntimeError; end
+  class LostLock                                  < RuntimeError; end
+  class LockUnavailable                           < RuntimeError; end
+  class MissingAttribute                          < RuntimeError; end
+  class MissingIndex                              < RuntimeError; end
+  class PolymorphicAssociationWithDifferentTypes  < RuntimeError; end
+  class ReadonlyField                             < RuntimeError; end
+  class UnknownAttribute                          < RuntimeError; end
 
   class DocumentInvalid < RuntimeError
     attr_accessor :instance

--- a/spec/integration/associations/belongs_to_polymorphic_spec.rb
+++ b/spec/integration/associations/belongs_to_polymorphic_spec.rb
@@ -1,0 +1,169 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'belongs_to polymorphic' do
+  before do
+    load_belongs_to_polymorphic_models
+    NoBrainer.sync_indexes
+  end
+
+  let(:event) { Event.create }
+  let!(:pictures) do
+    3.times.map { Picture.create(imageable: restaurant, mime: 'image/png') }
+  end
+  let(:restaurant) { Restaurant.create }
+
+  context 'setting polymorphic: true and class_name' do
+    it 'raises an error' do
+      expect do
+        Picture.belongs_to(:picturable, polymorphic: true, class_name: 'Test')
+      end.to raise_error(RuntimeError, /cannot set class_name on a polymorphic/)
+    end
+  end
+
+  context 'setting polymorphic: true and required but not assigning document' do
+    it 'raises an error' do
+      Picture.belongs_to(:picturable, polymorphic: true, required: true)
+
+      doc = Picture.create
+      expect { doc.save! }.to raise_error(NoBrainer::Error::DocumentInvalid)
+      doc.errors.full_messages.first.should == "Picturable can't be blank"
+    end
+  end
+
+  context 'when eager loading on a belongs_to association with all documents ' \
+          'from the same root class' do
+    it 'eagers load' do
+      expect(NoBrainer).to receive(:run).and_call_original.twice
+
+      Picture.eager_load(:imageable).each do |picture|
+        expect(picture.imageable).to eql(restaurant)
+      end
+    end
+  end
+
+  context 'when eager loading on a belongs_to association with at least one ' \
+          'document with a different root class' do
+    before { Picture.create(imageable: event, mime: 'image/png') }
+
+    it 'eagers load' do
+      expect do
+        Image.eager_load(:imageable).to_a
+      end.to raise_error(NoBrainer::Error::PolymorphicAssociationWithDifferentTypes)
+    end
+  end
+
+  context 'foreign_type is nil' do
+    context 'target is loaded' do
+      it 'returns the target' do
+        picture = Picture.create(imageable: restaurant)
+        picture.imageable_type = nil
+        picture.save!
+
+        expect(picture.imageable_type).to be_nil
+        expect(picture.imageable).to be(restaurant)
+      end
+    end
+
+    context 'target is not loaded' do
+      it 'returns nil' do
+        picture = Picture.create(imageable__id_: restaurant._id_)
+
+        expect(picture.imageable_type).to be_nil
+        expect(picture.imageable).to be_nil
+      end
+    end
+  end
+
+  context 'foreign_type is a non exiting class' do
+    it 'raises' do
+      expect do
+        Picture.create(imageable__id_: 'ABCD', imageable_type: 'SmartDeveloper')
+      end.to raise_error NameError, 'uninitialized constant SmartDeveloper'
+    end
+  end
+
+  context 'creating a polymorphic model document' do
+    it 'saves the model class as type and model id' do
+      picture = Picture.create(imageable: restaurant, mime: 'image/jpeg')
+
+      expect(picture.imageable_type).to eql(restaurant.class.name)
+      # `imageable__id_` instead of imageable_id since the primary key
+      # has been changed for Rspec, see spec/spec_helper.rb line 32-33.
+      expect(picture.imageable__id_).to eql(restaurant._id_)
+    end
+  end
+
+  context 'accessing a has_one polymorphic model document' do
+    it 'returns the associated document' do
+      # Do not use the imageable setter in order to prevent from loading it and
+      # being sure to pass into the polymorphic_read method, after the loaded?
+      logo = Logo.create(imageable_type: 'Restaurant',
+                         imageable__id_: restaurant._id_,
+                         mime: 'image/png')
+
+      expect(Restaurant.find(restaurant._id_).logo).to eql(Logo.find(logo._id_))
+    end
+  end
+
+  context 'accessing a has_many polymorphic model document' do
+    it 'returns the associated documents' do
+      picture1 = Picture.create(imageable: restaurant, mime: 'image/png')
+      picture2 = Picture.create(imageable: restaurant, mime: 'image/png')
+
+      expect(restaurant.pictures.to_a).to eql(pictures | [picture1, picture2])
+
+      picture3 = Picture.create(imageable: event, mime: 'image/png')
+
+      expect(event.photos.to_a).to eql([picture3])
+    end
+  end
+
+  context 'accessing a has_many through model document' do
+    it 'returns the associated documents' do
+      restaurant_event1 = Event.create(restaurant: restaurant)
+      restaurant_event2 = Event.create(restaurant: restaurant)
+
+      picture1 = Picture.create(imageable: restaurant_event1, mime: 'image/png')
+      picture2 = Picture.create(imageable: restaurant_event1, mime: 'image/png')
+      picture3 = Picture.create(imageable: restaurant_event2, mime: 'image/png')
+
+      expect(restaurant.photos.to_a).to eql([picture1, picture2, picture3])
+    end
+  end
+
+  context 'proxying a has_many association through a polymorphic association' do
+    it 'returns the associated documents' do
+      event = Event.create(restaurant: restaurant)
+
+      picture = Picture.create(imageable: event, mime: 'image/png')
+      guillaume = IdentifiedPerson.create(picture: picture,
+                                          fullname: 'Guillaume Briat')
+      alexandre = IdentifiedPerson.create(picture: picture,
+                                          fullname: 'Alexandre Astier')
+
+      picture = Picture.create(imageable: event, mime: 'image/png')
+      lionnel = IdentifiedPerson.create(picture: picture,
+                                        fullname: 'Lionnel Astier')
+      franck = IdentifiedPerson.create(picture: picture,
+                                       fullname: 'Franck Pitiot')
+
+      expect(event.people.to_a).to eql([guillaume, alexandre, lionnel, franck])
+    end
+  end
+
+  context 'joining on the imageable belongs_to' do
+    it 'fails' do
+      expect do
+        Picture.join(:imageable).map(&:imageable)
+      end.to raise_error(/join().*polymorphic/)
+    end
+  end
+
+  context 'joining on a has_many as: :imageable' do
+    it 'joins' do
+      expect(Restaurant.join(:pictures).flat_map(&:pictures)).to eql(pictures)
+    end
+  end
+end

--- a/spec/integration/criteria/eager_loading_spec.rb
+++ b/spec/integration/criteria/eager_loading_spec.rb
@@ -1,133 +1,172 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe 'eager_loading' do
   before { load_blog_models }
 
-  let!(:author)   { Author.create  }
-  let!(:posts)    { 3.times.map { |i| Post.create(:author => author, :title => i) } }
-  let!(:comments) { 3.times.map { |i| 3.times.map { |j| Comment.create(:post => author.posts[i], :body => j) } }.flatten }
+  let!(:author)   { Author.create! }
+  let!(:posts)    do
+    3.times.map { |i| Post.create!(:author => author, :title => i) }
+  end
+  let!(:comments) do
+    3.times.map do |i|
+      3.times.map do |j|
+        Comment.create!(:post => author.posts[i], :body => j)
+      end
+    end.flatten
+  end
 
   context 'when eager loading on a belongs_to association' do
     it 'eagers load' do
-      expect(NoBrainer).to receive(:run).and_call_original.exactly(2).times
+      expect(NoBrainer).to receive(:run).and_call_original.twice
+
       Comment.eager_load(:post).each do |comment|
-        comment.post.should == comments.select { |c| c == comment }.first.post
+        expect(comment.post).to eql(comments.select { |c| c == comment }.first.post)
       end
     end
   end
 
   context 'when eager loading on a has_many association' do
     it 'eagers load' do
-      expect(NoBrainer).to receive(:run).and_call_original.exactly(2).times
+      expect(NoBrainer).to receive(:run).and_call_original.twice
+
       Post.eager_load(:comments).each do |post|
-        post.comments.to_a.should == comments.select { |c| c.post == post }
+        expect(post.comments.to_a).to eql(comments.select { |c| c.post == post })
       end
     end
   end
 
   context 'when eager loading nested associations' do
     it 'eager loads' do
-      expect(NoBrainer).to receive(:run).and_call_original.exactly(3).times
+      expect(NoBrainer).to receive(:run).and_call_original.thrice
+
       a = Author.eager_load(:posts => [:author, :comments]).first
-      a.should == author
-      a.posts.to_a.should == posts
+
+      expect(a).to eql(author)
+      expect(a.posts.to_a).to eql(posts)
       a.posts.each do |post|
-        post.author.should == author
-        post.comments.to_a.should == comments.select { |c| c.post == post }
+        expect(post.author).to eql(author)
+        expect(post.comments.to_a).to eql(comments.select { |c| c.post == post })
       end
     end
   end
 
   context 'when eager loading nested associations with multiple eager_load' do
     it 'eager loads' do
-      expect(NoBrainer).to receive(:run).and_call_original.exactly(3).times
+      expect(NoBrainer).to receive(:run).and_call_original.thrice
+
       a = Author.eager_load(:posts => :author).eager_load(:posts => :comments).first
-      a.should == author
-      a.posts.to_a.should == posts
+
+      expect(a).to eql(author)
+      expect(a.posts.to_a).to eql(posts)
       a.posts.each do |post|
-        post.author.should == author
-        post.comments.to_a.should == comments.select { |c| c.post == post }
+        expect(post.author).to eql(author)
+        expect(post.comments.to_a).to eql(comments.select { |c| c.post == post })
       end
     end
   end
 
   context 'when eager loading after the fact' do
     it 'eager loads' do
-      expect(NoBrainer).to receive(:run).and_call_original.exactly(3).times
+      expect(NoBrainer).to receive(:run).and_call_original.thrice
+
       a = Author.eager_load(:posts => :comments).first
-      a.should == author
-      a.posts.to_a.should == posts
+
+      expect(a).to eql(author)
+      expect(a.posts.to_a).to eql(posts)
       a.posts.eager_load(:author).each do |post|
-        post.author.should == author
-        post.comments.to_a.should == comments.select { |c| c.post == post }
+        expect(post.author).to eql(author)
+        expect(post.comments.to_a).to eql(comments.select { |c| c.post == post })
       end
     end
   end
 
   context 'when eager loading after the fact on top of an existing eager load' do
     it 'eager loads' do
-      expect(NoBrainer).to receive(:run).and_call_original.exactly(3).times
+      expect(NoBrainer).to receive(:run).and_call_original.thrice
+
       a = Author.eager_load(:posts => [:author, :comments]).first
-      a.should == author
-      a.posts.to_a.should == posts
+
+      expect(a).to eql(author)
+      expect(a.posts.to_a).to eql(posts)
       a.posts.eager_load(:comments).each do |post|
-        post.author.should == author
-        post.comments.to_a.should == comments.select { |c| c.post == post }
+        expect(post.author).to eql(author)
+        expect(post.comments.to_a).to eql(comments.select { |c| c.post == post })
       end
     end
   end
 
   context 'when eager loading after the fact on top of a cached criteria' do
     it 'eager loads' do
-      expect(NoBrainer).to receive(:run).and_call_original.exactly(3).times
+      expect(NoBrainer).to receive(:run).and_call_original.thrice
+
       a = Author.first
-      a.should == author
-      a.posts.to_a.should == posts
+
+      expect(a).to eql(author)
+      expect(a.posts.to_a).to eql(posts)
+
       criteria = a.posts.eager_load(:comments)
+
       ([criteria.first] + criteria.to_a).each do |post|
-        post.comments.to_a.should == comments.select { |c| c.post == post }
+        expect(post.comments.to_a).to eql(comments.select { |c| c.post == post })
       end
     end
   end
 
   context 'when eager loading nested associations with criterias' do
     it 'eager loads' do
-      expect(NoBrainer).to receive(:run).and_call_original.exactly(3).times
-      a = Author.eager_load(:posts => Post.where(:title.gte => 1).eager_load(
-                            :author, :comments => Comment.where(:body.gte => 1))).first
-      a.should == author
-      a.posts.to_a.should == posts.select { |p| p.title >= 1 }
+      expect(NoBrainer).to receive(:run).and_call_original.thrice
+
+      a = Author.eager_load(
+        :posts => Post.where(:title.gte => 1).eager_load(
+          :author,
+          :comments => Comment.where(:body.gte => 1)
+        )
+      ).first
+
+      expect(a).to eql(author)
+      expect(a.posts.to_a).to eql(posts.select { |p| p.title >= 1 })
+
       a.posts.each do |post|
-        post.author.should == author
-        post.comments.to_a.should == comments.select { |c| c.post == post && c.body >= 1 }
+        expect(post.author).to eql(author)
+        expect(post.comments.to_a).to eql(comments.select { |c| c.post == post && c.body >= 1 })
       end
     end
   end
 
   context 'when eager loading scoped associations' do
-    before { Author.has_many :posts, :scope => ->{ where(:title.gte 1) } }
-    before { Post.has_many :comments, :scope => ->{ where(:body.gte 1) } }
+    before do
+      Author.has_many :posts, :scope => ->{ where(:title.gte 1) }
+      Post.has_many :comments, :scope => ->{ where(:body.gte 1) }
+    end
 
     it 'eager loads' do
-      expect(NoBrainer).to receive(:run).and_call_original.exactly(3).times
+      expect(NoBrainer).to receive(:run).and_call_original.thrice
+
       a = Author.eager_load(:posts => [:author, :comments]).first
-      a.should == author
-      a.posts.to_a.should == posts[1..2]
+
+      expect(a).to eql(author)
+      expect(a.posts.to_a).to eql(posts[1..2])
+
       a.posts.each do |post|
-        post.author.should == author
-        post.comments.to_a.should == comments.select { |c| c.post == post }[1..2]
+        expect(post.author).to eql(author)
+        expect(post.comments.to_a).to eql(comments.select { |c| c.post == post }[1..2])
       end
     end
   end
 
   context 'when eager loading an array of docs with NoBrainer.eager_load' do
     it 'eager loads' do
-      expect(NoBrainer).to receive(:run).and_call_original.exactly(2).times
+      expect(NoBrainer).to receive(:run).and_call_original.twice
+
       comments = Comment.all.to_a
-      comments = comments + comments
+
+      comments += comments
       NoBrainer.eager_load(comments, :post)
+
       comments.each do |comment|
-        comment.post.should == comments.select { |c| c == comment }.first.post
+        expect(comment.post).to eql(comments.select { |c| c == comment }.first.post)
       end
     end
   end

--- a/spec/support/models.rb
+++ b/spec/support/models.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'yaml'
 
 module ModelsHelper
@@ -124,35 +126,80 @@ module ModelsHelper
       field :partner_name
       field :partner_birthday
 
-      store :params, accessors: [ :token ], coder: YAML
-      store :settings, accessors: [ :color, :homepage ]
+      store :params, accessors: [:token], coder: YAML
+      store :settings, accessors: %i[color homepage]
       store_accessor :settings, :favorite_food
-      store :parent, accessors: [:birthday, :name], prefix: true
+      store :parent, accessors: %i[birthday name], prefix: true
       store :spouse, accessors: [:birthday], prefix: :partner
       store_accessor :spouse, :name, prefix: :partner
-      store :configs, accessors: [ :secret_question ]
-      store :configs, accessors: [ :two_factor_auth ], suffix: true
+      store :configs, accessors: [:secret_question]
+      store :configs, accessors: [:two_factor_auth], suffix: true
       store_accessor :configs, :login_retry, suffix: :config
-      store :preferences, accessors: [ :remember_login ]
-      store :json_data, accessors: [ :height, :weight ], coder: Coder.new
-      store :json_data_empty, accessors: [ :is_a_good_guy ], coder: Coder.new
+      store :preferences, accessors: [:remember_login]
+      store :json_data, accessors: %i[height weight], coder: Coder.new
+      store :json_data_empty, accessors: [:is_a_good_guy], coder: Coder.new
 
       def phone_number
         read_store_attribute(:settings, :phone_number).gsub(/(\d{3})(\d{3})(\d{4})/, '(\1) \2-\3')
       end
 
       def phone_number=(value)
-        write_store_attribute(:settings, :phone_number, value && value.gsub(/[^\d]/, ""))
+        write_store_attribute(:settings, :phone_number, value && value.gsub(/[^\d]/, ''))
       end
 
       def color
-        super || "red"
+        super || 'red'
       end
 
       def color=(value)
-        value = "blue" unless %w(black red green blue).include?(value)
+        value = 'blue' unless %w[black red green blue].include?(value)
         super
       end
+    end
+  end
+
+  def load_belongs_to_polymorphic_models
+    define_class :IdentifiedPerson do
+      include NoBrainer::Document
+
+      field :fullname
+
+      belongs_to :picture
+    end
+
+    define_class :Image do
+      include NoBrainer::Document
+
+      field :mime
+
+      belongs_to :imageable, polymorphic: true
+    end
+
+    define_class :Logo, Image do
+      include NoBrainer::Document
+    end
+
+    define_class :Picture, Image do
+      include NoBrainer::Document
+
+      has_many :people, class_name: 'IdentifiedPerson'
+    end
+
+    define_class :Event do
+      include NoBrainer::Document
+
+      belongs_to :restaurant
+      has_many :photos, class_name: 'Picture', as: :imageable
+      has_many :people, through: :photos
+    end
+
+    define_class :Restaurant do
+      include NoBrainer::Document
+
+      has_one :logo, as: :imageable
+      has_many :pictures, as: :imageable
+      has_many :events
+      has_many :photos, through: :events
     end
   end
 


### PR DESCRIPTION
This PR implements the polymorphic associations, the same way ActiveRecord does.

`belongs_to` now accepts the `polymorphic: true` and `has_many`/`has_one` the `as: :xxx`. Nobrainer adds 2 fields to the polymorphic model underthehood to store the foreign ID and Class then reuse them in query criteria.