### PR TITLE
Add support for partial compound index queries (closes #272)

### DIFF
--- a/lib/no_brainer/criteria/where.rb
+++ b/lib/no_brainer/criteria/where.rb
@@ -398,9 +398,19 @@ module NoBrainer::Criteria::Where
 
       get_usable_indexes(:kind => :compound, :geo => false, :multi => false).each do |index|
         indexed_clauses = index.what.map { |field| clauses[[field]] }
-        next unless indexed_clauses.all? { |c| c.try(:compatible_with_index?, index) }
+        if indexed_clauses.all? { |c| c.try(:compatible_with_index?, index) }
+          return IndexStrategy.new(self, ast, indexed_clauses, index, :get_all, [indexed_clauses.map(&:value)])
+        end
 
-        return IndexStrategy.new(self, ast, indexed_clauses, index, :get_all, [indexed_clauses.map(&:value)])
+        # use partial compound index if possible
+        partial_clauses = indexed_clauses.dup
+        partial_clauses.pop  while partial_clauses.last.nil?
+        if partial_clauses.all? { |c| c.try(:compatible_with_index?, index) }
+          pad = indexed_clauses.length - partial_clauses.length
+          left_bound  = partial_clauses.map(&:value) + Array.new(pad, RethinkDB::RQL.new.minval)
+          right_bound = partial_clauses.map(&:value) + Array.new(pad, RethinkDB::RQL.new.maxval)
+          return IndexStrategy.new(self, ast, partial_clauses, index, :between, [left_bound, right_bound], { left_bound: :open, right_bound: :open })
+        end
       end
       return nil
     end

--- a/spec/integration/index_spec.rb
+++ b/spec/integration/index_spec.rb
@@ -337,6 +337,7 @@ describe 'NoBrainer index' do
 
     let!(:doc1) { SimpleDocument.create(:field1 => 'hello', :field2 => 'world') }
     let!(:doc2) { SimpleDocument.create(:field1 => 'ohai',  :field2 => 'yay') }
+    let!(:doc3) { SimpleDocument.create(:field1 => 'hello', :field2 => 'springfield') }
 
     it 'uses the index' do
       SimpleDocument.where(:field12 => ['hello', 'world']).where_indexed?.should == true
@@ -346,6 +347,11 @@ describe 'NoBrainer index' do
     it 'uses an index when possible' do
       SimpleDocument.where(:field1 => 'ohai', :field2 => 'yay').used_index.should == :field12
       SimpleDocument.where(:field1 => 'ohai', :field2 => 'yay').count.should == 1
+    end
+
+    it 'uses a partial index when possible' do
+      SimpleDocument.where(:field1 => 'hello').used_index.should == :field12
+      SimpleDocument.where(:field1 => 'hello').count.should == 2
     end
 
     it 'does not allow to use a field with the same name as an index' do


### PR DESCRIPTION
Uses a compound index with a `between` query if all clauses are satisfied by a prefix of the index.