### PR TITLE
Fixes `first_or_create` with polymorphic association (Closes #288)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,5 +7,9 @@ AllCops:
 Metrics/BlockLength:
   IgnoredMethods: ['describe', 'context']
 
+Naming/RescuedExceptionsVariableName:
+  Enabled: Yes
+  PreferredName: error
+
 Style/Documentation:
   Enabled: No

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,16 +4,20 @@ services:
   rethinkdb:
     image: rethinkdb:2.4
 
+  # docker-compose run --rm gem [rspec [path to spec file]]
   gem:
     build: .
     image: nobrainerorm/nobrainer:latest
     depends_on:
       - rethinkdb
     environment:
-      - RUBY_ENV=test
       # The nobrainer Rspec config expects the DB_HOST variable
       # (see spec/spec_helper.rb), that's why we aren't setting the RDB_HOST env
       # variable here.
       - DB_HOST=rethinkdb
+      # Uncomment this line when you need to see NoBrainer logs while running
+      # the test suite.
+      # - DEBUG=1
+      - RUBY_ENV=test
     volumes:
       - .:/gem

--- a/lib/no_brainer/document/association.rb
+++ b/lib/no_brainer/document/association.rb
@@ -21,11 +21,12 @@ module NoBrainer::Document::Association
       super
     end
 
-    def association_user_to_model_cast(k,v)
-      association = association_metadata[k]
+    def association_user_to_model_cast(key, value, target_class = nil)
+      association = association_metadata[key]
       case association
-      when NoBrainer::Document::Association::BelongsTo::Metadata then association.cast_attr(k,v)
-      else [k,v]
+      when NoBrainer::Document::Association::BelongsTo::Metadata
+        association.cast_attr(key, value, target_class)
+      else [key, value]
       end
     end
 

--- a/lib/no_brainer/document/attributes.rb
+++ b/lib/no_brainer/document/attributes.rb
@@ -154,9 +154,17 @@ module NoBrainer::Document::Attributes
       !!fields[attr.to_sym]
     end
 
-    def ensure_valid_key!(key)
-      return if has_field?(key) || has_index?(key)
-      raise NoBrainer::Error::UnknownAttribute, "`#{key}' is not a valid attribute of #{self}"
+    def ensure_valid_key!(keys)
+      missings = Array(keys).select do |key|
+        has_field?(key) == false && has_index?(key) == false
+      end
+
+      return if missings.empty?
+
+      raise NoBrainer::Error::UnknownAttribute,
+            "`#{missings.join('\', `')}' #{missings.size > 1 ? 'are' : 'is'} " \
+            "not #{'a' if missings.size == 1} valid attribute" \
+            "#{'s' if missings.size > 1} of #{self}"
     end
   end
 end

--- a/spec/integration/associations/belongs_to_polymorphic_spec.rb
+++ b/spec/integration/associations/belongs_to_polymorphic_spec.rb
@@ -14,7 +14,7 @@ describe 'belongs_to polymorphic' do
   end
   let(:restaurant) { Restaurant.create }
 
-  context 'setting polymorphic: true and class_name' do
+  context 'when setting polymorphic: true and class_name' do
     it 'raises an error' do
       expect do
         Picture.belongs_to(:picturable, polymorphic: true, class_name: 'Test')
@@ -22,7 +22,7 @@ describe 'belongs_to polymorphic' do
     end
   end
 
-  context 'setting polymorphic: true and required but not assigning document' do
+  context 'when setting polymorphic: true and required but not assigning document' do
     it 'raises an error' do
       Picture.belongs_to(:picturable, polymorphic: true, required: true)
 

--- a/spec/integration/first_or_create_spec.rb
+++ b/spec/integration/first_or_create_spec.rb
@@ -1,19 +1,24 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe 'first_or_create' do
-  before { load_simple_document }
+  before do
+    load_simple_document
 
-  before { SimpleDocument.field :field1, :unique => true }
+    SimpleDocument.field(:field1, unique: true)
+  end
 
   context 'when the arguments are targeting an existing document' do
-    let!(:existing_doc) { SimpleDocument.create(:field1 => 1) }
+    let!(:existing_doc) { SimpleDocument.create(field1: 1) }
+
     it 'returns the document' do
-      SimpleDocument.where(:field1 => 1).first_or_create.should == existing_doc
-      SimpleDocument.count.should == 1
-      SimpleDocument.where(:field1 => 2).first_or_create.should == SimpleDocument.last
-      SimpleDocument.count.should == 2
-      SimpleDocument.where(:field1 => 2).first_or_create.should == SimpleDocument.last
-      SimpleDocument.count.should == 2
+      SimpleDocument.where(field1: 1).first_or_create.should eql existing_doc
+      SimpleDocument.count.should eql 1
+      SimpleDocument.where(field1: 2).first_or_create.should eql SimpleDocument.last
+      SimpleDocument.count.should eql 2
+      SimpleDocument.where(field1: 2).first_or_create.should eql SimpleDocument.last
+      SimpleDocument.count.should eql 2
     end
   end
 
@@ -28,35 +33,41 @@ describe 'first_or_create' do
 
     context 'due to a missing where()' do
       let(:query) { SimpleDocument.first_or_create }
+
       it_behaves_like 'failed first_or_create'
     end
 
     context 'due to an empty where()' do
       let(:query) { SimpleDocument.where({}).first_or_create }
       let(:err_msg) { /Missing.*clauses/ }
+
       it_behaves_like 'failed first_or_create'
     end
 
     context 'due to a non :and clause' do
-      let(:query) { SimpleDocument.where(:or => [{:field1 => 1}, {:field1 => 2}]).first_or_create }
+      let(:query) { SimpleDocument.where(or: [{ field1: 1 }, { field1: 2 }]).first_or_create }
+
       it_behaves_like 'failed first_or_create'
     end
 
     context 'due to a non scalar query' do
       let(:query) { SimpleDocument.where(:field1.any => 'xx').first_or_create }
       let(:err_msg) { /only use equal/ }
+
       it_behaves_like 'failed first_or_create'
     end
 
     context 'due to a non eq query' do
       let(:query) { SimpleDocument.where(:field1.lt => 'xx').first_or_create }
       let(:err_msg) { /only use equal/ }
+
       it_behaves_like 'failed first_or_create'
     end
 
     context 'due to a nested hash query' do
-      let(:query) { SimpleDocument.where(:field1 => {:xx => 'xx'}).first_or_create }
+      let(:query) { SimpleDocument.where(field1: { xx: 'xx' }).first_or_create }
       let(:err_msg) { /You may not use nested hash/ }
+
       it_behaves_like 'failed first_or_create'
     end
   end
@@ -64,14 +75,15 @@ describe 'first_or_create' do
   context 'when matching params between the where clause and the create params' do
     context 'when some keys are equal' do
       it 'works' do
-        SimpleDocument.where(:field1 => 123).first_or_create(:field1 => 123)
-        SimpleDocument.count.should == 1
+        SimpleDocument.where(field1: 123).first_or_create(field1: 123)
+        SimpleDocument.count.should eql 1
       end
     end
 
     context 'when failing due to a conflict' do
-      let(:query) { SimpleDocument.where(:field1 => 123).first_or_create(:field1 => 456) }
+      let(:query) { SimpleDocument.where(field1: 123).first_or_create(field1: 456) }
       let(:err_msg) { /conflicting values on the following keys: \[:field1\]/ }
+
       it_behaves_like 'failed first_or_create'
     end
   end
@@ -79,147 +91,195 @@ describe 'first_or_create' do
   context 'when passing arguments in the params block' do
     it 'raises' do
       expect do
-        SimpleDocument.where(:field1 => 123).first_or_create { |doc| }
+        SimpleDocument.where(field1: 123).first_or_create { |doc| }
       end.to raise_error(/no argument/)
     end
   end
 
   context 'when matching a uniqueness validator' do
-    before { SimpleDocument.field :field2, :uniq => {:scope => :field3} }
-    before { SimpleDocument.field :field3, :uniq => {:scope => [:field1, :field2]} }
-    before { SimpleDocument.field :field4 }
+    before do
+      SimpleDocument.field :field2, uniq: { scope: :field3 }
+      SimpleDocument.field :field3, uniq: { scope: %i[field1 field2] }
+      SimpleDocument.field :field4
+    end
 
     context 'when failing to match a validator' do
       context 'due to a missing one-clause validator' do
-        let(:query) { SimpleDocument.where(:field2 => 123).first_or_create }
+        let(:query) { SimpleDocument.where(field2: 123).first_or_create }
         let(:err_msg) { /field :field2, :uniq => true/ }
+
         it_behaves_like 'failed first_or_create'
       end
 
       context 'due to a missing two-clause validator' do
-        let(:query) { SimpleDocument.where(:field1 => 123, :field2 => 123).first_or_create }
+        let(:query) { SimpleDocument.where(field1: 123, field2: 123).first_or_create }
         let(:err_msg) { /field :field1, :uniq => {:scope => :field2}/ }
+
         it_behaves_like 'failed first_or_create'
       end
 
       context 'due to a missing N-clause validator' do
-        let(:query) { SimpleDocument.where(:field1 => 123, :field2 => 123, :field4 => 123).first_or_create }
+        let(:query) { SimpleDocument.where(field1: 123, field2: 123, field4: 123).first_or_create }
         let(:err_msg) { /field :field1, :uniq => {:scope => \[:field2, :field4\]}/ }
+
         it_behaves_like 'failed first_or_create'
       end
     end
 
     context 'when getting matches' do
       it 'works' do
-        SimpleDocument.where(:field3 => 123, :field2 => 123).first_or_create
-        SimpleDocument.where(:field3 => 123, :field2 => 123, :field1 => 123).first_or_create
+        SimpleDocument.where(field3: 123, field2: 123).first_or_create
+        SimpleDocument.where(field3: 123, field2: 123, field1: 123).first_or_create
         SimpleDocument.where(SimpleDocument.pk_name => '123').first_or_create
-        SimpleDocument.count.should == 2
+        SimpleDocument.count.should eql 2
       end
     end
   end
 
   context 'when validations fail' do
-    before { SimpleDocument.field :field2, :required => true }
+    before { SimpleDocument.field :field2, required: true }
 
     context 'when using first_or_create' do
       it 'returns a failing document' do
-        SimpleDocument.where(:field1 => 123).first_or_create.persisted?.should == false
+        SimpleDocument.where(field1: 123).first_or_create.persisted?.should be_falsey
       end
     end
 
     context 'when using first_or_create!' do
       it 'raises' do
-        expect { SimpleDocument.where(:field1 => 123).first_or_create! }
+        expect { SimpleDocument.where(field1: 123).first_or_create! }
           .to raise_error(NoBrainer::Error::DocumentInvalid)
       end
     end
   end
 
   context 'when using polymorphism' do
-    before { load_polymorphic_models }
-    before { Parent.field :parent_field, :uniq => true }
+    before do
+      load_polymorphic_models
+      Parent.field :parent_field, uniq: true
+    end
 
     context 'when passing a _type in create_params' do
       it 'creates the child subtype' do
-        doc = Parent.where(:parent_field => 123).first_or_create(:_type => :Child, :child_field => 123)
+        doc = Parent.where(parent_field: 123).first_or_create(_type: :Child, child_field: 123)
         doc.should be_a(Child)
-        doc.child_field.should == 123
+        doc.child_field.should eql 123
       end
     end
 
     context 'when passing a wrong _type in create_params' do
       it 'creates the child subtype' do
-        expect { Parent.where(:parent_field => 123).first_or_create(:_type => :SimpleDocument) }
+        expect { Parent.where(parent_field: 123).first_or_create(_type: :SimpleDocument) }
           .to raise_error(NoBrainer::Error::InvalidPolymorphicType)
       end
     end
 
     context 'when querying on a subclass with a field that belongs to the parent' do
       it 'raises' do
-        expect { Child.where(:parent_field => '123').first_or_create }
+        expect { Child.where(parent_field: '123').first_or_create }
           .to raise_error(/defined on `Parent'.*Parent.where.*:_type => "Child"/m)
       end
     end
 
     context 'when querying on a subclass with a field that belongs to the subclass' do
-      before { Child.field :child_field, :uniq => true }
+      before { Child.field :child_field, uniq: true }
+
       it 'creates the child subtype' do
-        doc = Child.where(:child_field => 123).first_or_create
+        doc = Child.where(child_field: 123).first_or_create
         doc.should be_a(Child)
-        doc.child_field.should == 123
+        doc.child_field.should eql 123
+      end
+    end
+  end
+
+  context 'when using belongs_to polymorphic association' do
+    before do
+      load_belongs_to_polymorphic_models
+
+      SimpleDocument.belongs_to(:picturable, polymorphic: true, uniq: true)
+
+      NoBrainer.sync_indexes
+    end
+
+    let(:identified_person) { IdentifiedPerson.create! }
+    let(:existing_doc) { SimpleDocument.create!(picturable: identified_person) }
+
+    context 'when query do not match any existing documents' do
+      it 'creates a new document' do
+        expect do
+          SimpleDocument.where(picturable: IdentifiedPerson.create!).first_or_create
+        end.to change(SimpleDocument, :count).by 1
+      end
+    end
+
+    context 'when querying existing documents' do
+      it 'does not create a document' do
+        SimpleDocument.create!(picturable: identified_person)
+
+        expect { SimpleDocument.where(picturable: identified_person).first_or_create }
+          .not_to(change(SimpleDocument, :count))
+      end
+
+      it 'returns existing documents' do
+        expected = existing_doc
+        expect(
+          SimpleDocument.where(picturable: identified_person).first_or_create
+        ).to eql(expected)
       end
     end
   end
 
   context 'when using upsert' do
     context 'when matching a uniqueness validator' do
-      before { SimpleDocument.field :field2, :uniq => {:scope => :field3} }
-      before { SimpleDocument.field :field3, :uniq => {:scope => [:field1, :field2]} }
-      before { SimpleDocument.field :field4 }
+      before do
+        SimpleDocument.field :field2, uniq: { scope: :field3 }
+        SimpleDocument.field :field3, uniq: { scope: %i[field1 field2] }
+        SimpleDocument.field :field4
+      end
 
       it 'creates documents' do
-        SimpleDocument.upsert(:field3 => 123, :field2 => 123)
-        SimpleDocument.upsert(:field3 => 123, :field2 => 123)
-        SimpleDocument.count.should == 1
+        SimpleDocument.upsert(field3: 123, field2: 123)
+        SimpleDocument.upsert(field3: 123, field2: 123)
+        SimpleDocument.count.should eql 1
 
-        SimpleDocument.upsert(:field3 => 456, :field2 => 456, :field1 => 456)
-        SimpleDocument.upsert(:field3 => 456, :field2 => 456, :field1 => 456)
-        SimpleDocument.count.should == 2
+        SimpleDocument.upsert(field3: 456, field2: 456, field1: 456)
+        SimpleDocument.upsert(field3: 456, field2: 456, field1: 456)
+        SimpleDocument.count.should eql 2
 
-        SimpleDocument.upsert(SimpleDocument.pk_name => '123', :field4 => 123)
-        SimpleDocument.upsert(SimpleDocument.pk_name => '123', :field4 => 123)
-        SimpleDocument.count.should == 3
-        SimpleDocument.find('123').field4.should == 123
+        SimpleDocument.upsert(SimpleDocument.pk_name => '123', field4: 123)
+        SimpleDocument.upsert(SimpleDocument.pk_name => '123', field4: 123)
+        SimpleDocument.count.should eql 3
+
+        SimpleDocument.find('123').field4.should eql 123
       end
 
       it 'updates documents' do
-        attrs = { :field1 => 123, :field2 => 123 }
+        attrs = { field1: 123, field2: 123 }
         SimpleDocument.upsert(attrs)
-        SimpleDocument.count.should == 1
-        SimpleDocument.first.attributes.symbolize_keys.slice(*attrs.keys).should == attrs
+        SimpleDocument.count.should eql 1
+        SimpleDocument.first.attributes.symbolize_keys.slice(*attrs.keys).should eql attrs
 
-        attrs = { :field1 => 123, :field2 => 456 }
+        attrs = { field1: 123, field2: 456 }
         SimpleDocument.upsert(attrs)
-        SimpleDocument.count.should == 1
-        SimpleDocument.first.attributes.symbolize_keys.slice(*attrs.keys).should == attrs
+        SimpleDocument.count.should eql 1
+        SimpleDocument.first.attributes.symbolize_keys.slice(*attrs.keys).should eql attrs
       end
     end
 
     context 'when not matching a uniqueness validator' do
       it 'errors' do
-        expect { SimpleDocument.upsert(:field2 => 123) }
+        expect { SimpleDocument.upsert(field2: 123) }
           .to raise_error(/Could not find a uniqueness validator.*field2/)
-        expect { SimpleDocument.upsert(:field2 => 123, :field3 => 123) }
+        expect { SimpleDocument.upsert(field2: 123, field3: 123) }
           .to raise_error(/Could not find a uniqueness validator.*field2.*field3/)
       end
 
       context 'when validations fail' do
-        before { SimpleDocument.field :field2, :required => true }
+        before { SimpleDocument.field :field2, required: true }
 
         context 'when using upsert' do
           it 'returns a failing document' do
-            SimpleDocument.upsert({}).persisted?.should == false
+            SimpleDocument.upsert({}).persisted?.should be_falsey
           end
         end
 
@@ -234,17 +294,17 @@ describe 'first_or_create' do
 
     context 'when matching a uniqueness validator with validations' do
       context 'when validations fail' do
-        before { SimpleDocument.field :field2, :required => true }
+        before { SimpleDocument.field :field2, required: true }
 
         context 'when using upsert' do
           it 'returns a failing document' do
-            SimpleDocument.upsert(:field1 => 123).persisted?.should == false
+            SimpleDocument.upsert(field1: 123).persisted?.should be_falsey
           end
         end
 
         context 'when using upsert!' do
           it 'raises' do
-            expect { SimpleDocument.upsert!(:field1 => 123) }
+            expect { SimpleDocument.upsert!(field1: 123) }
               .to raise_error(NoBrainer::Error::DocumentInvalid)
           end
         end
@@ -252,14 +312,17 @@ describe 'first_or_create' do
     end
 
     context 'when matching a uniqueness validator with a belongs_to' do
-      before { load_blog_models }
-      before { Comment.belongs_to :post, :uniq => true }
+      before do
+        load_blog_models
+        Comment.belongs_to :post, uniq: true
+      end
+
       let(:post) { Post.create }
 
       it 'upserts with model instances as foreign keys' do
-        Comment.upsert(:post => post)
-        Comment.upsert(:post => post)
-        Comment.count.should == 1
+        Comment.upsert(post: post)
+        Comment.upsert(post: post)
+        Comment.count.should eql 1
       end
     end
   end


### PR DESCRIPTION
Closes #288

This PR fixes running `Model.where(...).first_or_create`.

The NoBrainer documentation needs to be updated in order to tell about the `uniq: true` or `unique: true` option to be set in order to get the `first_or_create` to work.