### PR TITLE
Implements `index: { defined: true }` index

### DIFF
--- a/lib/no_brainer/criteria/where.rb
+++ b/lib/no_brainer/criteria/where.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module NoBrainer::Criteria::Where
   extend ActiveSupport::Concern
   include ActiveModel::ForbiddenAttributesProtection
@@ -342,8 +344,8 @@ module NoBrainer::Criteria::Where
     # Ruby's /m modifier means that . matches \n and corresponds to RE2's "s" flag.
 
     flags = "m"
-    flags << "s" if value.options & Regexp::MULTILINE != 0
-    flags << "i" if value.options & Regexp::IGNORECASE != 0
+    flags += "s" if value.options & Regexp::MULTILINE != 0
+    flags += "i" if value.options & Regexp::IGNORECASE != 0
 
     "(?#{flags})#{value.source}"
   end


### PR DESCRIPTION
This PR adds the `defined: true` option to the `index` method allowing to only index documents having the given field.

```ruby
class MyDoc
  include NoBrainer::Document

  # Using the field options
  field :field1, index: { defined: true }
  field :field2
  field :field3

  # Using the index method
  index :field2, defined: true
end
```

The following queries will use the above declared indexes:

```ruby
MyDoc.where(:field1.defined => true).count

MyDoc.where(:field1.defined => true, :field2.defined => true).count
```