### PR TITLE
Updates Github Action matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
         include:
           - ruby: 2.2
             rails: 4
-            eventmachine: true
+            eventmachine: false
           - ruby: 2.3
             rails: 5
             eventmachine: false
@@ -28,9 +28,18 @@ jobs:
           - ruby: 2.7
             rails: 6
             eventmachine: false
+          - ruby: 2.7
+            rails: 6
+            eventmachine: true
           - ruby: 3
             rails: 6
             eventmachine: false
+          - ruby: 3
+            rails: 6
+            eventmachine: true
+          - ruby: 3
+            rails: 7
+            eventmachine: true
           - ruby: 3
             rails: 7
             eventmachine: false

--- a/Earthfile
+++ b/Earthfile
@@ -1,3 +1,5 @@
+VERSION 0.6
+
 # This allows one to change the running Ruby version with:
 #
 # `earthly --build-arg EARTHLY_RUBY_VERSION=3 --allow-privileged +rspec`
@@ -16,6 +18,12 @@ deps:
     COPY gemfiles/rails$EARTHLY_RAILS_VERSION.gemfile /gem/Gemfile
     COPY *.gemspec /gem
 
+    IF ruby -e "exit 0 if $EARTHLY_RUBY_VERSION < 2.4; exit 1"
+        RUN echo "deb http://archive.debian.org/debian stretch main" > /etc/apt/sources.list
+    ELSE
+        RUN echo "No need to archive repo yet."
+    END
+
     RUN apt update \
         && apt install --yes \
                        --no-install-recommends \
@@ -28,6 +36,12 @@ deps:
     SAVE ARTIFACT /gem/Gemfile.lock Gemfile.lock
 
 dev:
+    IF ruby -e "exit 0 if $EARTHLY_RUBY_VERSION < 2.4; exit 1"
+        RUN echo "deb http://archive.debian.org/debian stretch main" > /etc/apt/sources.list
+    ELSE
+        RUN echo "No need to archive repo yet."
+    END
+
     RUN apt update \
         && apt install --yes \
                        --no-install-recommends \

--- a/gemfiles/rails4.gemfile
+++ b/gemfiles/rails4.gemfile
@@ -3,7 +3,7 @@
 source 'https://rubygems.org'
 gemspec
 
-gem 'eventmachine' if ENV['EM']
+gem 'eventmachine' if ENV['EM'] == 'true'
 gem 'rspec', '~> 3.10'
 gem 'timecop'
 

--- a/gemfiles/rails5.gemfile
+++ b/gemfiles/rails5.gemfile
@@ -3,7 +3,7 @@
 source 'https://rubygems.org'
 gemspec
 
-gem 'eventmachine' if ENV['EM']
+gem 'eventmachine' if ENV['EM'] == 'true'
 gem 'rspec', '~> 3.10'
 gem 'timecop'
 

--- a/gemfiles/rails6.gemfile
+++ b/gemfiles/rails6.gemfile
@@ -3,7 +3,7 @@
 source 'https://rubygems.org'
 gemspec
 
-gem 'eventmachine' if ENV['EM']
+gem 'eventmachine' if ENV['EM'] == 'true'
 gem 'rspec', '~> 3.10'
 gem 'timecop'
 

--- a/gemfiles/rails7.gemfile
+++ b/gemfiles/rails7.gemfile
@@ -3,7 +3,7 @@
 source 'https://rubygems.org'
 gemspec
 
-gem 'eventmachine' if ENV['EM']
+gem 'eventmachine' if ENV['EM'] == 'true'
 gem 'rspec', '~> 3.10'
 gem 'timecop'
 

--- a/spec/integration/connection_spec.rb
+++ b/spec/integration/connection_spec.rb
@@ -1,9 +1,11 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 # FIXME We are not really testing that many connections are gettings used, but
 # at least it will exercice the code.
 
-unless ENV['EM']
+unless ENV['EM'] == 'true'
   describe 'connection' do
     before { load_simple_document }
     before { SimpleDocument.count } # ensure the table is created

--- a/spec/integration/criteria/changes_spec.rb
+++ b/spec/integration/criteria/changes_spec.rb
@@ -1,15 +1,17 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe 'changes' do
   before { load_simple_document }
   before { SimpleDocument.count } # ensure the table is created
-  before { NoBrainer.configure { |c| c.per_thread_connection = true } } unless ENV['EM']
+  before { NoBrainer.configure { |c| c.per_thread_connection = true } } unless ENV['EM'] == 'true'
 
   let!(:recorded_changes) { [] }
   after { @thread.try(:kill) } # FIXME leaking connections :)
 
   def record_changes
-    return em_record_changes if ENV['EM']
+    return em_record_changes if ENV['EM'] == 'true'
 
     @thread = Thread.new do
       begin

--- a/spec/integration/criteria/enumerable_spec.rb
+++ b/spec/integration/criteria/enumerable_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe "each" do
@@ -119,7 +121,7 @@ describe "each" do
       it_behaves_like 'streams'
     end
 
-    if ENV['EM']
+    if ENV['EM'] == 'true'
       context 'when using raw changes' do
         let(:criteria) { SimpleDocument.raw.changes(:include_states => true) }
         it_behaves_like 'streams'

--- a/spec/integration/query_runner_spec.rb
+++ b/spec/integration/query_runner_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe "NoBrainer query runner" do
@@ -14,7 +16,7 @@ describe "NoBrainer query runner" do
     end
   end
 
-  unless ENV['EM'] # see https://github.com/rethinkdb/rethinkdb/issues/5929
+  unless ENV['EM'] == 'true' # see https://github.com/rethinkdb/rethinkdb/issues/5929
     describe 'run_with' do
       it 'passes down options to r.run()' do
         NoBrainer.run_with(:profile => true) do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 load './spec/support/_coverage.rb' if ENV['COVERAGE']
 require 'rubygems'
 require 'bundler'
@@ -37,10 +39,10 @@ nobrainer_conf = proc do |c|
   c.rethinkdb_url = "rethinkdb://#{database_host}/#{db_name}"
   c.environment = :test
   c.logger = Logger.new(STDERR).tap { |l| l.level = ENV['DEBUG'] ? Logger::DEBUG : Logger::WARN }
-  c.driver = :em if ENV['EM']
+  c.driver = :em if ENV['EM'] == 'true'
 end
 
-if ENV['EM']
+if ENV['EM'] == 'true'
   require 'fiber'
   class RSpec::Core:: Runner
     alias_method :orig_run_specs, :run_specs

--- a/spec/support/eventually.rb
+++ b/spec/support/eventually.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module EventuallyHelper
   extend self
 
@@ -12,7 +14,7 @@ module EventuallyHelper
       end
       return if error.nil?
       raise error if Time.now >= time_limit
-      if ENV['EM']
+      if ENV['EM'] == 'true'
         f = Fiber.current
         EM::Timer.new(interval) { f.resume }
         Fiber.yield


### PR DESCRIPTION
Eventmachine with Ruby 2.2 doesn't work anymore since Debian Stretch removal, plus eventmachine is not tested with recent Ruby/Rails versions.

This PR updates the Github Action matrix determining Ruby / Rails / Eventmachine attributes.